### PR TITLE
FEATURE: added tab attaching and console, object to core protocol specifications

### DIFF
--- a/specification/core.json
+++ b/specification/core.json
@@ -70,7 +70,84 @@
 
         "consoleActor": "console",
         "traceActor": "trace"
+      },
+      "methods": [
+         {
+          "name": "attach",
+          "request": {},
+          "response": { "_retval": "json" }
+         }
+      ],
+      "events": {
+        "tabNavigated": {
+           "typeName": "tabNavigated"
+        }
       }
+    },
+    "console": {
+      "category": "actor",
+      "typeName": "console",
+      "methods": [
+        {
+          "name": "evaluateJS",
+          "request": {
+            "text": {
+              "_option": 0,
+              "type": "string"
+            },
+            "url": {
+              "_option": 1,
+              "type": "string"
+            },
+            "bindObjectActor": {
+              "_option": 2,
+              "type": "nullable:string"
+            },
+            "frameActor": {
+              "_option": 2,
+              "type": "nullable:string"
+            },
+            "selectedNodeActor": {
+              "_option": 2,
+              "type": "nullable:string"
+            }
+          },
+          "response": {
+            "_retval": "evaluatejsresponse"
+          }
+        }
+      ],
+      "events": {}
+    },
+    "evaluatejsresponse": {
+      "category": "dict",
+      "typeName": "evaluatejsresponse",
+      "specializations": {
+        "result": "object",
+        "exception": "object",
+        "exceptionMessage": "string",
+        "input": "string"
+      }
+    },
+    "object": {
+      "category": "actor",
+      "typeName": "object",
+      "methods": [
+         {
+           "name": "property",
+           "request": {
+              "name": {
+                "_arg": 0,
+                "type": "string"
+              }
+           },
+           "response": {
+              "descriptor": {
+                "_retval": "json"
+              }
+           }
+         }
+      ]
     }
   }
 }


### PR DESCRIPTION
This commit adds a couple of feature to the core.json protocol specifications:
- tab.attach method signature (needed to start receiving tabNavigated events)
- tab events (currently only tabNavigated)
- basic console actor protocol description (currently only the evaluateJS method signature)
- basic object actor protocol description (currently only the property method signature)

This protocol descriptions are guessed from reply packets and actor code, so they need to be checked and completed (or the related actors ported to protocol.js) 
